### PR TITLE
Add shader messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,12 +50,9 @@ checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
 
 [[package]]
 name = "cexpr"

--- a/glslang-sys/Cargo.toml
+++ b/glslang-sys/Cargo.toml
@@ -18,4 +18,4 @@ license = "MIT OR Apache-2.0"
 
 [build-dependencies]
 glob = "0.3.1"
-cc = "1.0"
+cc = "1.0.104"

--- a/glslang-sys/build.rs
+++ b/glslang-sys/build.rs
@@ -26,6 +26,7 @@ pub fn main() {
 
     let mut glslang_build = cc::Build::new();
     glslang_build
+        .cpp(true)
         .std("c++17")
         .define("ENABLE_HLSL", "ON")
         .define("ENABLE_OPT", "OFF")

--- a/glslang/src/program.rs
+++ b/glslang/src/program.rs
@@ -170,7 +170,7 @@ mod tests {
     use super::*;
     use crate::ctypes::ShaderStage;
     use crate::shader::{CompilerOptions, OpenGlVersion, ShaderInput, ShaderSource, Target};
-    use crate::{GlslProfile, SourceLanguage};
+    use crate::{GlslProfile, ShaderMessage, SourceLanguage};
     use rspirv::binary::Disassemble;
 
     #[test]
@@ -198,7 +198,7 @@ void main() {
             None,
         )
             .expect("target");
-        let shader = Shader::new(&compiler, input).expect("shader init");
+        let _shader = Shader::new(&compiler, input).expect("shader init");
 
         let program = Program::new(&compiler);
         // program.add_shader(&shader);
@@ -281,6 +281,7 @@ void main() {
                     version: OpenGlVersion::OpenGL4_5,
                     spirv_version: None,
                 },
+                messages: ShaderMessage::DEBUG_INFO | ShaderMessage::DEFAULT,
                 version_profile: Some((890, GlslProfile::None)),
             },
             None,
@@ -314,6 +315,7 @@ void main() {
             &CompilerOptions {
                 source_language: SourceLanguage::GLSL,
                 target: Target::None(None),
+                messages: ShaderMessage::DEBUG_INFO | ShaderMessage::DEFAULT,
                 version_profile: None,
             },
             None,

--- a/glslang/src/shader.rs
+++ b/glslang/src/shader.rs
@@ -411,10 +411,24 @@ impl Target {
 #[derive(Debug, Clone)]
 pub struct ShaderMessage(pub i32);
 
-impl ShaderMessage {
+impl ShaderMessage {    
     pub const DEFAULT: ShaderMessage = ShaderMessage(sys::glslang_messages_t::DEFAULT.0);
-    pub const DEBUG_INFO: ShaderMessage = ShaderMessage(sys::glslang_messages_t::DEBUG_INFO.0);
+    pub const RELAXED_ERRORS: ShaderMessage = ShaderMessage(sys::glslang_messages_t::RELAXED_ERRORS.0);
+    pub const SUPPRESS_WARNINGS: ShaderMessage = ShaderMessage(sys::glslang_messages_t::SUPPRESS_WARNINGS.0);
+    pub const AST: ShaderMessage = ShaderMessage(sys::glslang_messages_t::AST.0);
+    pub const SPV_RULES: ShaderMessage = ShaderMessage(sys::glslang_messages_t::SPV_RULES.0);
+    pub const VULKAN_RULES: ShaderMessage = ShaderMessage(sys::glslang_messages_t::VULKAN_RULES.0);
+    pub const ONLY_PREPROCESSOR: ShaderMessage = ShaderMessage(sys::glslang_messages_t::ONLY_PREPROCESSOR.0);
+    pub const READ_HLSL: ShaderMessage = ShaderMessage(sys::glslang_messages_t::READ_HLSL.0);
     pub const CASCADING_ERRORS: ShaderMessage = ShaderMessage(sys::glslang_messages_t::CASCADING_ERRORS.0);
+    pub const KEEP_UNCALLED: ShaderMessage = ShaderMessage(sys::glslang_messages_t::KEEP_UNCALLED.0);
+    pub const HLSL_OFFSETS: ShaderMessage = ShaderMessage(sys::glslang_messages_t::HLSL_OFFSETS.0);
+    pub const DEBUG_INFO: ShaderMessage = ShaderMessage(sys::glslang_messages_t::DEBUG_INFO.0);
+    pub const HLSL_ENABLE_16BIT_TYPES: ShaderMessage = ShaderMessage(sys::glslang_messages_t::HLSL_ENABLE_16BIT_TYPES.0);
+    pub const HLSL_LEGALIZATION: ShaderMessage = ShaderMessage(sys::glslang_messages_t::HLSL_LEGALIZATION.0);
+    pub const HLSL_DX9_COMPATIBLE: ShaderMessage = ShaderMessage(sys::glslang_messages_t::HLSL_DX9_COMPATIBLE.0);
+    pub const BUILTIN_SYMBOL_TABLE: ShaderMessage = ShaderMessage(sys::glslang_messages_t::BUILTIN_SYMBOL_TABLE.0);
+    pub const ENHANCED: ShaderMessage = ShaderMessage(sys::glslang_messages_t::ENHANCED.0);
 
     pub fn convert(&self) -> sys::glslang_messages_t {
         sys::glslang_messages_t(self.0)


### PR DESCRIPTION
The glsl shader messages options where not accessible from the rust API, with this PR, I am making them accessible. 
I also upgraded the glslang and cc-rs version to support a new target support for wasi platform. I can move these change to another PR if you prefer.