### PR TITLE
Using include handler instead of callback & add macro support

### DIFF
--- a/glslang/src/program.rs
+++ b/glslang/src/program.rs
@@ -197,6 +197,7 @@ void main() {
             &source,
             ShaderStage::Fragment,
             &CompilerOptions::default(),
+            &[],
             None,
         )
             .expect("target");
@@ -231,6 +232,7 @@ void main() {
             &source,
             ShaderStage::Fragment,
             &CompilerOptions::default(),
+            &[],
             None,
         )
         .expect("target");
@@ -286,6 +288,7 @@ void main() {
                 messages: ShaderMessage::DEBUG_INFO | ShaderMessage::DEFAULT,
                 version_profile: Some((120, GlslProfile::None)),
             },
+            &[],
             None,
         )
         .expect("target");
@@ -320,6 +323,7 @@ void main() {
                 messages: ShaderMessage::DEBUG_INFO | ShaderMessage::DEFAULT,
                 version_profile: None,
             },
+            &[],
             None,
         )
         .expect("target");
@@ -371,6 +375,7 @@ void main()
             &fragment,
             ShaderStage::Fragment,
             &CompilerOptions::default(),
+            &[],
             None,
         )
         .expect("target");
@@ -382,6 +387,7 @@ void main()
             &vertex,
             ShaderStage::Vertex,
             &CompilerOptions::default(),
+            &[],
             None,
         )
         .expect("target");

--- a/glslang/src/program.rs
+++ b/glslang/src/program.rs
@@ -493,5 +493,7 @@ void main() {
         )
         .expect("target");
         let _shader = Shader::new(&compiler, input).expect("shader init");
+        assert!(include_handler.header_included.len() == 1);
+        assert_eq!(include_handler.header_included[0], "custom_include.glsl", "");
     }
 }

--- a/glslang/src/shader.rs
+++ b/glslang/src/shader.rs
@@ -1,10 +1,11 @@
 use crate::ctypes::{ResourceType, ShaderOptions, ShaderStage};
 use crate::error::GlslangError;
 use crate::error::GlslangError::ParseError;
-use crate::include::IncludeCallback;
+use crate::include::IncludeHandler;
 use crate::{include, limits, limits::ResourceLimits, Compiler};
 use glslang_sys as sys;
 use glslang_sys::glsl_include_callbacks_s;
+use std::collections::HashMap;
 use std::ffi::{c_void, CStr, CString};
 use std::ptr::NonNull;
 use bitflags::bitflags;
@@ -30,6 +31,17 @@ impl<'a> Shader<'a> {
             is_spirv: input.input.target_language == sys::glslang_target_language_t::SPIRV,
             _compiler,
         };
+
+        let preamble = input.defines
+            .iter()
+            .map(|(k, v)| format!("#define {} {}\n", k, v.clone().unwrap_or_default()))
+            .collect::<Vec<String>>()
+            .join("");
+
+        let cpreamble = CString::new(preamble).expect("Invalid preamble format");
+        unsafe {
+            sys::glslang_shader_set_preamble(shader.handle.as_ptr(), cpreamble.as_ptr());
+        }
 
         unsafe {
             if sys::glslang_shader_preprocess(shader.handle.as_ptr(), &input.input) == 0 {
@@ -81,17 +93,6 @@ impl<'a> Shader<'a> {
     #[allow(unused)]
     fn glsl_version(&mut self, version: i32) {
         unsafe { sys::glslang_shader_set_glsl_version(self.handle.as_ptr(), version) }
-    }
-
-    /// Set the preamble of the shader source.
-    /// This doesn't actually seem to do anything and has the potential for unsoundness.
-    #[doc(hidden)]
-    #[allow(unused)]
-    fn preamble(&mut self, preamble: String) {
-        let cstr = CString::new(preamble).expect("rust string should not have interior null bytes");
-        unsafe {
-            sys::glslang_shader_set_preamble(self.handle.as_ptr(), cstr.as_ptr());
-        }
     }
 
     fn get_log(&self) -> String {
@@ -170,6 +171,7 @@ void main() {
             &source,
             ShaderStage::Fragment,
             &CompilerOptions::default(),
+            &[],
             None,
         )
         .expect("target");
@@ -242,6 +244,7 @@ pub struct ShaderInput<'a> {
     // Keep these alive.
     _source: &'a ShaderSource,
     _resource: &'a sys::glslang_resource_t,
+    pub(crate) defines: HashMap<String, Option<String>>,
     pub(crate) input: sys::glslang_input_t,
 }
 
@@ -481,9 +484,10 @@ impl<'a> ShaderInput<'a> {
         source: &'a ShaderSource,
         stage: ShaderStage,
         options: &CompilerOptions,
-        includer: Option<IncludeCallback>,
+        defines: &[(&str, Option<&str>)],
+        include_handler: Option<&'a mut dyn IncludeHandler>,
     ) -> Result<Self, GlslangError> {
-        Self::new_with_limits(source, &limits::DEFAULT_LIMITS, stage, options, includer)
+        Self::new_with_limits(source, &limits::DEFAULT_LIMITS, stage, options, defines, include_handler)
     }
 
 
@@ -493,7 +497,8 @@ impl<'a> ShaderInput<'a> {
         resource: &'a ResourceLimits,
         stage: ShaderStage,
         options: &CompilerOptions,
-        includer: Option<IncludeCallback>,
+        defines: &[(&str, Option<&str>)],
+        include_handler: Option<&'a mut dyn IncludeHandler>,
     ) -> Result<Self, GlslangError> {
         let profile = options
             .version_profile
@@ -503,13 +508,14 @@ impl<'a> ShaderInput<'a> {
             options.target.verify_glsl_profile(profile.as_ref())?;
         }
 
-        let callbacks_ctx = includer.map_or(core::ptr::null_mut(), |callback| {
+        let callbacks_ctx = include_handler.map_or(core::ptr::null_mut(), |callback| {
             Box::into_raw(Box::new(callback))
         });
 
         Ok(Self {
             _source: source,
             _resource: &resource.0,
+            defines: defines.iter().map(|v| (String::from(v.0), v.1.map(|s| s.to_string()))).collect(),
             input: sys::glslang_input_t {
                 language: options.source_language,
                 stage,


### PR DESCRIPTION
Hello,

I have another PR for some include support: 
In order to improve it, I replaced the basic callback by a mutable trait so that we can store informations from includes and use them (I tried to mimic the hassle-rs crate which does quite the same but with DXC). I also moved the preamble function call which need to be called before preprocess & parsing (which was not possible before this as we need to create the struct in order to call it, but it is then too late to call it) and use it to add macros to the shader, I think this is the only way to add macros to shaders.