### PR TITLE
Swap the lifetime constraint order on Program::add_shader

### DIFF
--- a/glslang/src/program.rs
+++ b/glslang/src/program.rs
@@ -32,7 +32,7 @@ impl<'a> Program<'a> {
     /// Add a shader to the program. The lifetime of the shader must extend beyond the lifetime of the program instance.
     pub fn add_shader<'shader>(&mut self, shader: &'shader Shader<'shader>)
     where
-        'a: 'shader,
+        'shader: 'a,
     {
         unsafe { sys::glslang_program_add_shader(self.handle.as_ptr(), shader.handle.as_ptr()) }
         self.cache.insert(shader.stage, shader.is_spirv);


### PR DESCRIPTION
Fixes #9

With my program described in #9 I was able to make a local modification to the crate with this lifetime swap, and I got a borrow checker error at compile time instead of a segfault at runtime.

Related changes:

https://github.com/SnowflakePowered/glslang-rs/commit/aa1e824bd3efacead6f0e8647f706919901a524a#diff-d0111935127bb27d0623849f5470fa2def936a4192976b432e2949dfc2f43604R33

https://github.com/SnowflakePowered/glslang-rs/commit/09734322b0debdc7a1d2408405565f9afff21488#diff-d0111935127bb27d0623849f5470fa2def936a4192976b432e2949dfc2f43604L33-R32