### PR TITLE
Add access to debug log from error

### DIFF
--- a/glslang/src/error.rs
+++ b/glslang/src/error.rs
@@ -3,21 +3,42 @@ use crate::shader::Target;
 use crate::GlslProfile;
 use thiserror::Error;
 
+/// The error logs
+#[derive(Debug)]
+pub struct GlslangErrorLog {
+    pub log: String,
+    pub debug_log: String,
+}
+
+impl GlslangErrorLog {
+    pub fn new(log: String, debug_log: String) -> Self {
+        Self {
+            log, debug_log
+        }
+    }
+}
+
+impl std::fmt::Display for GlslangErrorLog {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Log:\n{}\nDebugLog:\n{}", self.log, self.debug_log)
+    }
+}
+
 /// The error type for `glslang`.
 #[derive(Debug, Error)]
 pub enum GlslangError {
     /// Error occurred when preprocessing.
     #[error("preprocess error: {0}")]
-    PreprocessError(String),
+    PreprocessError(GlslangErrorLog),
     /// Error occurred when preprocessing.
     #[error("parse error: {0}")]
-    ParseError(String),
+    ParseError(GlslangErrorLog),
     /// Error occurred when mapping IO.
     #[error("map io error: {0}")]
-    MapIoError(String),
+    MapIoError(GlslangErrorLog),
     /// Error occurred when linking
     #[error("program link error: {0}")]
-    LinkError(String),
+    LinkError(GlslangErrorLog),
     /// The shader stage was not found in the program.
     #[error("shader stage not found: {0:?}")]
     ShaderStageNotFound(ShaderStage),


### PR DESCRIPTION
Hello, I was playing with the ShaderMessage::AST flag and noticed that the output is printed in the debug log which is not accessible with the current Rust API. 

With this PR I look into making it accessible. Instead of returning a string as error, it returns a struct with both standard logs and debug logs.